### PR TITLE
Adjust markdown for GFM

### DIFF
--- a/chapter6/chapter6.md
+++ b/chapter6/chapter6.md
@@ -135,7 +135,7 @@ The main core modules, classes, methods, and events include:
 
 These are the most important core modules. Let's cover each of them.
 
-###http
+### http
 
 
 This is the main module responsible for Node.js HTTP server. Here are
@@ -170,7 +170,7 @@ the main methods:
 
     -   `response.end()`: sends and ends a response body
 
-###util
+### util
 
 
 This module provides utilities for debugging. Some of the methods
@@ -188,14 +188,14 @@ the methods include:
 
 -   `querystring.parse()`: Deserialize a query string to an object
 
-###url
+### url
 
 This module has utilities for URL resolution and parsing. Some of the
 methods include:
 
 -   `parse()`: Take a URL string, and return an object
 
-###fs
+### fs
 
 fs handles file system operations such as reading and writing to/from
 files. There are synchronous and asynchronous methods in the library.


### PR DESCRIPTION
Headers should have a space between # and the title to be correctly parsed by the GFM. https://guides.github.com/features/mastering-markdown/